### PR TITLE
change canonical to ubuntu

### DIFF
--- a/content/news/2021-07-24-thank-you-canonical/index.md
+++ b/content/news/2021-07-24-thank-you-canonical/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Thank you to Canonical for Join as Diamond Sponsor!"
+title: "Thank you to Ubuntu for Join as Diamond Sponsor!"
 date: 2021-07-24T01:49:00+07:00
 authors:
     - name: Sartika Lestari
@@ -12,13 +12,13 @@ authors:
       linklabel: Website
 ---
 
-We are gladly to announce Canonical as our part of **Diamond Sponsor**.
+We are gladly to announce Ubuntu as our part of **Diamond Sponsor**.
 
-As the publisher of Ubuntu, the OS for most public cloud workloads to advanced robots, Canonical provides enterprise security, support, and services for commercial users of Ubuntu. 
-Canonical is responsible for delivering six-monthly milestone releases and regular LTS releases for enterprise production use including the entire online infrastructure for community interaction. 
-Enterprises count on Canonical to support, secure and manage Ubuntu infrastructure and devices.
+The Ubuntu desktop as we know is the world's most widely used Linux workstation platform, powering the work of engineers across the globe. Ubuntu today has many flavours and dozens of specialized derivatives. All share common infrastructure and software, making Ubuntu a unique single platform that scales from consumer electronics to the desktop and up into the cloud for enterprise computing. 
 
-With joining **Ubucon Asia 2021**, Canonical also help and support community and its lifecycle to keep developing, collaborating, inovating, and contributing to open-source. 
-Please check and find out more about our Diamond Sponsor Canonical here https://2021.ubucon.asia/sponsors/ubuntu/
+As the publisher of Ubuntu, the OS for most public cloud workloads to advanced robots, Canonical provides enterprise security, support, and services for commercial users of Ubuntu. Canonical is responsible for delivering six-monthly milestone releases and regular LTS releases for enterprise production use including the entire online infrastructure for community interaction. Enterprises count on Canonical to support, secure and manage Ubuntu infrastructure and devices.
+
+With joining **Ubucon Asia 2021**, Ubuntu Canonical also helps and support community and its lifecycle to keep developing, collaborating, innovating, and contributing to open-source. 
+Please check and find out more about our Diamond Sponsor, Ubuntu here https://2021.ubucon.asia/sponsors/ubuntu/
 
 Don't forget to have reservation and come to Ubucon Asia 2021 on Sept 25th - 26th. See the registration https://eventyay.com/e/75ac7f83


### PR DESCRIPTION
We are gladly to announce ```Canonical``` as our part of **Diamond Sponsor**.
**Changed to:**
We are gladly to announce ```Ubuntu``` as our part of **Diamond Sponsor**

**Added:**
The Ubuntu desktop as we know is the world's most widely used Linux workstation platform, powering the work of engineers across the globe. Ubuntu today has many flavours and dozens of specialised derivatives. All share common infrastructure and software, making Ubuntu a unique single platform that scales from consumer electronics to the desktop and up into the cloud for enterprise computing. 

With joining **Ubucon Asia 2021**, ```Canonical``` also help and support community and its lifecycle to keep developing, collaborating, inovating, and contributing to open-source. 
Please check and find out more about our Diamond Sponsor, ```Canonical``` here https://2021.ubucon.asia/sponsors/ubuntu/
**Changed to:**
With joining **Ubucon Asia 2021**, ```Ubuntu Canonical``` also help and support community and its lifecycle to keep developing, collaborating, inovating, and contributing to open-source. 
Please check and find out more about our Diamond Sponsor, ```Ubuntu``` here https://2021.ubucon.asia/sponsors/ubuntu/